### PR TITLE
Add Basic Authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.class
 
+**/logs/*
 *.log
 *.out
 

--- a/server/apache-tomcat-9.0.5/webapps/engine-rest/WEB-INF/web.xml
+++ b/server/apache-tomcat-9.0.5/webapps/engine-rest/WEB-INF/web.xml
@@ -27,7 +27,7 @@
   </filter-mapping>
   
   <!-- Http Basic Authentication Filter -->
-  <!-- <filter>
+  <filter>
     <filter-name>camunda-auth</filter-name>
     <filter-class>
       org.camunda.bpm.engine.rest.security.auth.ProcessEngineAuthenticationFilter


### PR DESCRIPTION
Now, it is necessary to provide user and password to hit endpoints
(https://en.wikipedia.org/wiki/Basic_access_authentication).

With a user = demo and password = demo, for example, we can hit an
endpoint using ruby Typhoeus this way:

request = Typhoeus::Request.new('http://localhost:8080/engine-rest/user', userpwd: 'demo:demo')
response = request.run